### PR TITLE
Keep name preview compact beside design controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+tsconfig.tsbuildinfo
+src/**/*.js

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -18,11 +18,17 @@ export default function Hero({
         />
       </div>
 
-      <div className="absolute inset-x-0 bottom-6 flex justify-center gap-3 pointer-events-none">
-        <button onClick={onPrimary} className="px-6 py-3 rounded-2xl bg-black text-white shadow pointer-events-auto">
+      <div className="absolute inset-x-0 bottom-4 flex flex-col items-center gap-2 px-4 pointer-events-none sm:bottom-6 sm:flex-row sm:justify-center sm:gap-3">
+        <button
+          onClick={onPrimary}
+          className="w-full max-w-[320px] px-6 py-3 rounded-2xl bg-black text-white shadow pointer-events-auto sm:w-auto"
+        >
           作ってみる
         </button>
-        <button onClick={onSecondary} className="px-6 py-3 rounded-2xl bg-white shadow pointer-events-auto">
+        <button
+          onClick={onSecondary}
+          className="w-full max-w-[320px] px-6 py-3 rounded-2xl bg-white shadow pointer-events-auto sm:w-auto"
+        >
           法人問い合わせ
         </button>
       </div>

--- a/src/components/NameTilePreview.tsx
+++ b/src/components/NameTilePreview.tsx
@@ -138,7 +138,7 @@ export default function NameTilePreview(props: {
     const handle = () => update(el.clientWidth || baseWidth);
     window.addEventListener("resize", handle);
     return () => window.removeEventListener("resize", handle);
-  }, [widthCeiling, minWidth]);
+  }, [widthCeiling, minWidth, baseWidth]);
 
   const height = Math.round(width / aspect);
   const padding = 10;

--- a/src/components/NameTilePreview.tsx
+++ b/src/components/NameTilePreview.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from "react";
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 export type Layout = "vertical" | "horizontal";
 export type ColorKey = "black" | "red" | "blue" | "green" | "pink" | "rainbow";
@@ -38,8 +38,19 @@ export default function NameTilePreview(props: {
   unifiedColor: ColorKey;
   perCharColors: ColorKey[];
   fontKey?: "ta-fuga-fude" | "gothic" | "mincho";
+  maxWidth?: number;
+  minWidth?: number;
 }) {
-  const { text, layout, useUnifiedColor, unifiedColor, perCharColors, fontKey = "ta-fuga-fude" } = props;
+  const {
+    text,
+    layout,
+    useUnifiedColor,
+    unifiedColor,
+    perCharColors,
+    fontKey = "ta-fuga-fude",
+    maxWidth,
+    minWidth = 200,
+  } = props;
 
   // === Typekit を onload で読み込み（onreadystatechange は使用しない） ===
   useEffect(() => {
@@ -80,9 +91,55 @@ export default function NameTilePreview(props: {
 
   const chars = useMemo(() => Array.from(text || ""), [text]);
   const groups = useMemo(() => splitTwoLines(chars), [chars]);
+  const groupOffsets = useMemo(() => {
+    const offsets: number[] = [];
+    let running = 0;
+    groups.forEach((group) => {
+      offsets.push(running);
+      running += group.length;
+    });
+    return offsets;
+  }, [groups]);
 
-  const width = layout === "vertical" ? 360 : 580;
+  const baseWidth = layout === "vertical" ? 360 : 580;
+  const widthCeiling = Math.max(minWidth, Math.min(maxWidth ?? baseWidth, baseWidth));
   const aspect = layout === "vertical" ? 21 / 28 : 28 / 21;
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [width, setWidth] = useState(widthCeiling);
+  const tileInnerRef = useRef<HTMLDivElement | null>(null);
+  const textContentRef = useRef<HTMLDivElement | null>(null);
+  const [scale, setScale] = useState(1);
+
+  useEffect(() => {
+    setWidth((prev) => Math.min(prev, widthCeiling));
+  }, [widthCeiling]);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const update = (nextWidth: number) => {
+      const clamped = Math.max(minWidth, Math.min(widthCeiling, Math.round(nextWidth)));
+      setWidth(clamped);
+    };
+
+    update(el.clientWidth || widthCeiling);
+
+    if (typeof ResizeObserver !== "undefined") {
+      const observer = new ResizeObserver((entries) => {
+        const entry = entries[0];
+        if (!entry) return;
+        update(entry.contentRect.width);
+      });
+      observer.observe(el);
+      return () => observer.disconnect();
+    }
+
+    const handle = () => update(el.clientWidth || baseWidth);
+    window.addEventListener("resize", handle);
+    return () => window.removeEventListener("resize", handle);
+  }, [widthCeiling, minWidth]);
+
   const height = Math.round(width / aspect);
   const padding = 10;
   const shortSide = Math.min(width, height) - padding * 2;
@@ -114,9 +171,67 @@ export default function NameTilePreview(props: {
       })();
 
   const colorAt = (index: number): ColorKey => (colors[index] ? colors[index] : "black");
+  const colorSignature = colors.join(",");
+  const textSignature = chars.join("");
+
+  useEffect(() => {
+    setScale(1);
+  }, [textSignature, layout, fontKey, colorSignature]);
+
+  useLayoutEffect(() => {
+    const measure = () => {
+      const inner = tileInnerRef.current;
+      const content = textContentRef.current;
+      if (!inner || !content) return;
+
+      const innerWidth = inner.clientWidth;
+      const innerHeight = inner.clientHeight;
+      const contentWidth = content.offsetWidth;
+      const contentHeight = content.offsetHeight;
+
+      if (!innerWidth || !innerHeight || !contentWidth || !contentHeight) {
+        setScale(1);
+        return;
+      }
+
+      const next = Math.min(innerWidth / contentWidth, innerHeight / contentHeight, 1);
+      setScale((prev) => (Math.abs(prev - next) > 0.01 ? next : prev));
+    };
+
+    let raf = requestAnimationFrame(measure);
+
+    const inner = tileInnerRef.current;
+    const content = textContentRef.current;
+    if (!inner || !content) {
+      return () => cancelAnimationFrame(raf);
+    }
+
+    if (typeof ResizeObserver !== "undefined") {
+      const observer = new ResizeObserver(() => {
+        cancelAnimationFrame(raf);
+        raf = requestAnimationFrame(measure);
+      });
+      observer.observe(inner);
+      observer.observe(content);
+      return () => {
+        observer.disconnect();
+        cancelAnimationFrame(raf);
+      };
+    }
+
+    const handle = () => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(measure);
+    };
+    window.addEventListener("resize", handle);
+    return () => {
+      window.removeEventListener("resize", handle);
+      cancelAnimationFrame(raf);
+    };
+  }, [textSignature, layout, fontKey, colorSignature, width, height]);
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-2" ref={containerRef} style={{ width: "100%", maxWidth: widthCeiling, margin: "0 auto" }}>
       <div
         className="mx-auto select-none shadow-[0_8px_20px_rgba(0,0,0,.08)] bg-white"
         style={{
@@ -130,53 +245,84 @@ export default function NameTilePreview(props: {
           padding,
         }}
       >
-        {layout === "vertical" ? (
-          <div style={{ display: "flex", gap: 8, flexDirection: "row-reverse" }}>
-            {groups.map((col, ci) => (
-              <div
-                key={ci}
-                style={{
-                  writingMode: "vertical-rl",
-                  textOrientation: "upright",
-                  fontFamily: FONT_STACKS[fontKey],
-                  fontSize,
-                  lineHeight: 1.05,
-                  display: "flex",
-                  alignItems: "center",
-                }}
-              >
-                {col.map((ch, i) => (
-                  <span key={i} style={colorStyle(colorAt(ci * (groups[0].length || 0) + i))}>
-                    {ch}
-                  </span>
-                ))}
-              </div>
-            ))}
+        <div
+          ref={tileInnerRef}
+          style={{
+            position: "relative",
+            width: "100%",
+            height: "100%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            overflow: "hidden",
+          }}
+        >
+          <div
+            style={{
+              transform: `scale(${scale})`,
+              transformOrigin: "center center",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <div ref={textContentRef}>
+              {layout === "vertical" ? (
+                <div style={{ display: "flex", gap: 8, flexDirection: "row-reverse" }}>
+                  {groups.map((col, ci) => (
+                    <div
+                      key={ci}
+                      style={{
+                        writingMode: "vertical-rl",
+                        textOrientation: "upright",
+                        fontFamily: FONT_STACKS[fontKey],
+                        fontSize,
+                        lineHeight: 1.05,
+                        display: "flex",
+                        alignItems: "center",
+                      }}
+                    >
+                      {col.map((ch, i) => {
+                        const color = colorStyle(colorAt(groupOffsets[ci] + i));
+                        return (
+                          <span key={i} style={color}>
+                            {ch}
+                          </span>
+                        );
+                      })}
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div style={{ display: "flex", flexDirection: "column", gap: 6, width: "92%", textAlign: "center" }}>
+                  {groups.map((row, ri) => (
+                    <div
+                      key={ri}
+                      style={{
+                        fontFamily: FONT_STACKS[fontKey],
+                        fontSize,
+                        lineHeight: 1.0,
+                        display: "flex",
+                        justifyContent: "center",
+                        gap: 8,
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {row.map((ch, i) => {
+                        const color = colorStyle(colorAt(groupOffsets[ri] + i));
+                        return (
+                          <span key={i} style={color}>
+                            {ch}
+                          </span>
+                        );
+                      })}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
           </div>
-        ) : (
-          <div style={{ display: "flex", flexDirection: "column", gap: 6, width: "92%", textAlign: "center" }}>
-            {groups.map((row, ri) => (
-              <div
-                key={ri}
-                style={{
-                  fontFamily: FONT_STACKS[fontKey],
-                  fontSize,
-                  lineHeight: 1.0,
-                  display: "flex",
-                  justifyContent: "center",
-                  gap: 8,
-                  whiteSpace: "nowrap",
-                }}
-              >
-                {row.map((ch, i) => (
-                  <span key={i} style={colorStyle(colorAt(ri * (groups[0].length || 0) + i))}>
-                    {ch}
-                  </span>
-                ))}
-              </div>
-            ))}
-          </div>
-        )}
+        </div>
       </div>
 
       <p className="text-xs text-neutral-500 text-center">

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -6,9 +6,9 @@ export default function Nav() {
 
   return (
     <header className="sticky top-0 z-40 bg-white/80 backdrop-blur border-b">
-      <div className="container-narrow h-14 flex items-center justify-between">
-        <div className="font-bold">one牌</div>
-        <nav className="flex items-center gap-1">
+      <div className="container-narrow flex flex-wrap items-center justify-between gap-2 py-2 sm:h-14">
+        <div className="font-bold text-lg">one牌</div>
+        <nav className="flex flex-wrap items-center gap-1 sm:gap-2">
           <button className={navBtn} onClick={() => goto("#/")}>ショップ</button>
           <button className={navBtn} onClick={() => goto("#/guidelines")}>入稿規定</button>
           <button className={navBtn} onClick={() => goto("#/corporate")}>法人問い合わせ</button>

--- a/src/components/Pill.tsx
+++ b/src/components/Pill.tsx
@@ -1,18 +1,22 @@
 import React from "react";
 import { motion } from "framer-motion";
 
+type Tone = "neutral" | "slate" | "indigo" | "emerald" | "amber" | "rose";
+
 type Props = {
   active?: boolean;
+  tone?: Tone;
   onClick?: () => void;
   className?: string;
   children: React.ReactNode;
 };
 
-const Pill: React.FC<Props> = ({ active, onClick, className = "", children }) => {
+const Pill: React.FC<Props> = ({ active, tone = "neutral", onClick, className = "", children }) => {
   return (
     <motion.button
       type="button"
       whileTap={{ scale: 0.98 }}
+      data-tone={tone}
       className={`pill ${active ? "pill-active" : ""} ${className}`}
       onClick={onClick}
     >

--- a/src/styles.css
+++ b/src/styles.css
@@ -23,11 +23,48 @@
     @apply btn bg-white border-neutral-200 hover:bg-neutral-50;
   }
   .pill {
-    @apply inline-flex items-center gap-2 rounded-xl border px-3 py-2 text-sm
-           transition hover:ring-1 hover:ring-neutral-200 select-none;
+    @apply inline-flex items-center gap-2 rounded-xl border px-3 py-2 text-sm font-medium
+           transition select-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2
+           focus-visible:outline-black/30;
   }
-  .pill-active {
-    @apply bg-black text-white border-black hover:ring-0;
+  .pill:hover {
+    @apply -translate-y-[1px];
+  }
+  .pill[data-tone="neutral"] {
+    @apply bg-white border-neutral-200 text-neutral-700 hover:bg-neutral-50 shadow-[0_2px_8px_rgba(15,23,42,0.06)];
+  }
+  .pill[data-tone="neutral"].pill-active {
+    @apply bg-neutral-900 border-neutral-900 text-white shadow-[0_12px_28px_rgba(15,23,42,0.25)];
+  }
+  .pill[data-tone="slate"] {
+    @apply bg-slate-50 border-slate-200 text-slate-700 hover:bg-slate-100 shadow-[0_2px_8px_rgba(30,41,59,0.08)];
+  }
+  .pill[data-tone="slate"].pill-active {
+    @apply bg-slate-800 border-slate-800 text-white shadow-[0_12px_26px_rgba(30,41,59,0.28)];
+  }
+  .pill[data-tone="indigo"] {
+    @apply bg-indigo-50 border-indigo-200 text-indigo-700 hover:bg-indigo-100 shadow-[0_2px_8px_rgba(79,70,229,0.12)];
+  }
+  .pill[data-tone="indigo"].pill-active {
+    @apply bg-indigo-600 border-indigo-600 text-white shadow-[0_14px_30px_rgba(79,70,229,0.35)];
+  }
+  .pill[data-tone="emerald"] {
+    @apply bg-emerald-50 border-emerald-200 text-emerald-700 hover:bg-emerald-100 shadow-[0_2px_8px_rgba(16,185,129,0.12)];
+  }
+  .pill[data-tone="emerald"].pill-active {
+    @apply bg-emerald-600 border-emerald-600 text-white shadow-[0_14px_30px_rgba(16,185,129,0.32)];
+  }
+  .pill[data-tone="amber"] {
+    @apply bg-amber-50 border-amber-200 text-amber-700 hover:bg-amber-100 shadow-[0_2px_8px_rgba(217,119,6,0.14)];
+  }
+  .pill[data-tone="amber"].pill-active {
+    @apply bg-amber-500 border-amber-500 text-white shadow-[0_14px_30px_rgba(217,119,6,0.32)];
+  }
+  .pill[data-tone="rose"] {
+    @apply bg-rose-50 border-rose-200 text-rose-700 hover:bg-rose-100 shadow-[0_2px_8px_rgba(244,63,94,0.14)];
+  }
+  .pill[data-tone="rose"].pill-active {
+    @apply bg-rose-500 border-rose-500 text-white shadow-[0_14px_30px_rgba(244,63,94,0.32)];
   }
 }
 

--- a/src/views/Shop.tsx
+++ b/src/views/Shop.tsx
@@ -27,6 +27,9 @@ const fmt = (n: number) => new Intl.NumberFormat("ja-JP").format(n);
 const splitChars = (s: string) => Array.from(s || "");
 const suitLabel = (s: "manzu" | "souzu" | "pinzu") => (s === "manzu" ? "萬子" : s === "souzu" ? "索子" : "筒子");
 const containerStyle: React.CSSProperties = { maxWidth: "min(1024px, 92vw)", margin: "0 auto" };
+const formRowClass = "flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3";
+const formRowContentClass = "flex flex-wrap gap-2";
+const formLabelClass = "text-sm font-medium sm:w-24";
 const BOTTOM_BAR_HEIGHT = 76;
 
 const COLOR_LIST: { key: ColorKey; label: string; css: string }[] = [
@@ -141,11 +144,8 @@ const Shop: React.FC<{ gotoCorporate: () => void }> = ({ gotoCorporate }) => {
 
   const productUnit = est.unit;
   const extraDetails = est.extras;
-  const optionsUnit = est.optionTotal;          // 単価（見積で qty 掛け）
-  const optionsSubtotal = est.optionTotal * qty;
   const discountRate = est.discountRate;
   const discountAmount = est.discountAmount;
-  const productSubtotal = est.unit * qty;
   const merchandiseSubtotal = est.merchandiseSubtotal;
   const shipping = est.shipping;
   const total = est.total;
@@ -200,9 +200,6 @@ const Shop: React.FC<{ gotoCorporate: () => void }> = ({ gotoCorporate }) => {
     return "デザイン依頼（別途お見積り）";
   };
 
-  /** カート計算ヘルパ（各アイテムの小計：割引はここでは引かない） */
-  const lineTotal = (ci: CartItem) => ci.qty * ci.unit + ci.qty * ci.optionTotal;
-
   /** カート追加 */
   const addToCart = () => {
     const item: CartItem = {
@@ -250,104 +247,104 @@ const Shop: React.FC<{ gotoCorporate: () => void }> = ({ gotoCorporate }) => {
       <Hero onPrimary={scrollToSelect} onSecondary={gotoCorporate} />
 
       <section style={containerStyle} className="mt-6 space-y-6">
-{/* 1. カテゴリ */}
-<Card title="1. カテゴリを選択">
-  <div ref={selectRef} className="grid grid-cols-1 md:grid-cols-2 gap-5">
-    {/* オリジナル麻雀牌 */}
-    <button
-      type="button"
-      onClick={() => {
-        setFlow(originalSub === "fullset" ? "fullset" : "original_single");
-      }}
-      className={`group relative text-left rounded-2xl border transition hover:shadow ${
-        flow !== "regular" ? "border-black" : "border-neutral-200"
-      } p-0 overflow-hidden`}
-    >
-      {/* 画像をカード全面に。上下左右の余白ナシ */}
-      <div className="relative h-[180px] md:h-[220px]">
-        <img
-          src={asset("category-original.jpg")}
-          alt="オリジナル麻雀牌"
-          className="absolute inset-0 w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
-          loading="lazy"
-          decoding="async"
-        />
-      </div>
+        {/* 1. カテゴリ */}
+        <Card title="1. カテゴリを選択">
+          <div ref={selectRef} className="grid grid-cols-1 gap-5 md:grid-cols-2">
+            {/* オリジナル麻雀牌 */}
+            <button
+              type="button"
+              onClick={() => {
+                setFlow(originalSub === "fullset" ? "fullset" : "original_single");
+              }}
+              className={`group relative text-left rounded-2xl border transition hover:shadow ${
+                flow !== "regular" ? "border-black" : "border-neutral-200"
+              } p-0 overflow-hidden`}
+            >
+              <div className="relative h-[180px] md:h-[220px]">
+                <img
+                  src={asset("category-original.jpg")}
+                  alt="オリジナル麻雀牌"
+                  className="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </div>
 
-      {/* テキストは内側に余白 */}
-      <div className="p-4">
-        <div className="text-base font-semibold">オリジナル麻雀牌</div>
-        <div className="text-xs text-neutral-500 mt-0.5">28mm / 30mm</div>
-        <div className="text-[12px] text-neutral-700 mt-2">
-          あなただけのオリジナル牌を作成。アクセサリーやギフトにも最適です。
-        </div>
-      </div>
-    </button>
+              <div className="p-4">
+                <div className="text-base font-semibold">オリジナル麻雀牌</div>
+                <div className="mt-0.5 text-xs text-neutral-500">28mm / 30mm</div>
+                <div className="mt-2 text-[12px] text-neutral-700">
+                  あなただけのオリジナル牌を作成。アクセサリーやギフトにも最適です。
+                </div>
+              </div>
+            </button>
 
-    {/* 通常牌（バラ売り） */}
-    <button
-      type="button"
-      onClick={() => setFlow("regular")}
-      className={`group relative text-left rounded-2xl border transition hover:shadow ${
-        flow === "regular" ? "border-black" : "border-neutral-200"
-      } p-0 overflow-hidden`}
-    >
-      <div className="relative h-[180px] md:h-[220px]">
-        <img
-          src={asset("category-regular.jpg")}
-          alt="通常牌（バラ売り）"
-          className="absolute inset-0 w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
-          loading="lazy"
-          decoding="async"
-        />
-      </div>
+            {/* 通常牌（バラ売り） */}
+            <button
+              type="button"
+              onClick={() => setFlow("regular")}
+              className={`group relative text-left rounded-2xl border transition hover:shadow ${
+                flow === "regular" ? "border-black" : "border-neutral-200"
+              } p-0 overflow-hidden`}
+            >
+              <div className="relative h-[180px] md:h-[220px]">
+                <img
+                  src={asset("category-regular.jpg")}
+                  alt="通常牌（バラ売り）"
+                  className="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </div>
 
-      <div className="p-4">
-        <div className="text-base font-semibold">通常牌（バラ売り）</div>
-        <div className="text-xs text-neutral-500 mt-0.5">28mm</div>
-        <div className="text-[12px] text-neutral-700 mt-2">
-          通常牌も1枚からご購入いただけます。もちろんキーホルダー対応も！
-        </div>
-      </div>
-    </button>
-  </div>
-
-  {/* 28/30mmや納期の注記（通常牌以外のときだけ表示） */}
-  {flow !== "regular" && (
-    <div className="mt-3">
-      <div className="flex flex-wrap gap-2">
-        <Pill
-          active={originalSub === "single"}
-          onClick={() => {
-            setOriginalSub("single");
-            setFlow("original_single");
-          }}
-        >
-          1つから
-        </Pill>
-        <Pill
-          active={originalSub === "fullset"}
-          onClick={() => {
-            setOriginalSub("fullset");
-            setFlow("fullset");
-          }}
-        >
-          フルセット
-        </Pill>
-      </div>
-
-      {/* 納期（選択時のみ表示） */}
-      <div className="mt-3 text-xs text-neutral-600 space-y-1">
-        {flow === "original_single" && <div>発送目安：<b>約2〜3週間</b></div>}
-        {flow === "fullset" && (
-          <div>
-            納期：<b>デザイン確定から2〜3か月</b>
+              <div className="p-4">
+                <div className="text-base font-semibold">通常牌（バラ売り）</div>
+                <div className="mt-0.5 text-xs text-neutral-500">28mm</div>
+                <div className="mt-2 text-[12px] text-neutral-700">
+                  通常牌も1枚からご購入いただけます。もちろんキーホルダー対応も！
+                </div>
+              </div>
+            </button>
           </div>
-        )}
-      </div>
-    </div>
-  )}
-</Card>
+
+          {/* 28/30mmや納期の注記（通常牌以外のときだけ表示） */}
+          {flow !== "regular" && (
+            <div className="mt-3">
+              <div className="flex flex-wrap gap-2">
+                <Pill
+                  tone="indigo"
+                  active={originalSub === "single"}
+                  onClick={() => {
+                    setOriginalSub("single");
+                    setFlow("original_single");
+                  }}
+                >
+                  1つから
+                </Pill>
+                <Pill
+                  tone="indigo"
+                  active={originalSub === "fullset"}
+                  onClick={() => {
+                    setOriginalSub("fullset");
+                    setFlow("fullset");
+                  }}
+                >
+                  フルセット
+                </Pill>
+              </div>
+
+              {/* 納期（選択時のみ表示） */}
+              <div className="mt-3 space-y-1 text-xs text-neutral-600">
+                {flow === "original_single" && <div>発送目安：<b>約2〜3週間</b></div>}
+                {flow === "fullset" && (
+                  <div>
+                    納期：<b>デザイン確定から2〜3か月</b>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </Card>
 
 
         {/* 2. 分岐 */}
@@ -355,30 +352,30 @@ const Shop: React.FC<{ gotoCorporate: () => void }> = ({ gotoCorporate }) => {
           <Card title="2. 牌の選択（通常牌）">
             <div className="grid md:grid-cols-2 gap-6 items-start">
               <div className="space-y-3">
-                <div className="flex items-center gap-2">
-                  <label className="w-24">背面色</label>
-                  <Pill active={regularBack === "yellow"} onClick={() => setRegularBack("yellow")}>黄色</Pill>
-                  <Pill active={regularBack === "blue"} onClick={() => setRegularBack("blue")}>青色</Pill>
+                <div className={formRowClass}>
+                  <label className={formLabelClass}>背面色</label>
+                  <Pill tone="slate" active={regularBack === "yellow"} onClick={() => setRegularBack("yellow")}>黄色</Pill>
+                  <Pill tone="slate" active={regularBack === "blue"} onClick={() => setRegularBack("blue")}>青色</Pill>
                 </div>
-                <div className="flex items-center gap-2">
-                  <label className="w-24">種別</label>
-                  <Pill active={regularSuit === "honor"} onClick={() => setRegularSuit("honor")}>字牌</Pill>
-                  <Pill active={regularSuit === "manzu"} onClick={() => setRegularSuit("manzu")}>萬子</Pill>
-                  <Pill active={regularSuit === "souzu"} onClick={() => setRegularSuit("souzu")}>索子</Pill>
-                  <Pill active={regularSuit === "pinzu"} onClick={() => setRegularSuit("pinzu")}>筒子</Pill>
+                <div className={formRowClass}>
+                  <label className={formLabelClass}>種別</label>
+                  <Pill tone="emerald" active={regularSuit === "honor"} onClick={() => setRegularSuit("honor")}>字牌</Pill>
+                  <Pill tone="emerald" active={regularSuit === "manzu"} onClick={() => setRegularSuit("manzu")}>萬子</Pill>
+                  <Pill tone="emerald" active={regularSuit === "souzu"} onClick={() => setRegularSuit("souzu")}>索子</Pill>
+                  <Pill tone="emerald" active={regularSuit === "pinzu"} onClick={() => setRegularSuit("pinzu")}>筒子</Pill>
                 </div>
                 {regularSuit === "honor" ? (
-                  <div className="flex items-center gap-2">
-                    <label className="w-24">字牌</label>
+                  <div className={formRowClass}>
+                    <label className={formLabelClass}>字牌</label>
                     {["東", "南", "西", "北", "白", "發", "中"].map((h) => (
-                      <Pill key={h} active={regularHonor === (h as any)} onClick={() => setRegularHonor(h as any)}>{h}</Pill>
+                      <Pill tone="rose" key={h} active={regularHonor === (h as any)} onClick={() => setRegularHonor(h as any)}>{h}</Pill>
                     ))}
                   </div>
                 ) : (
-                  <div className="flex items-center gap-2">
-                    <label className="w-24">数字</label>
+                  <div className={formRowClass}>
+                    <label className={formLabelClass}>数字</label>
                     {Array.from({ length: 9 }).map((_, i) => (
-                      <Pill key={i + 1} active={regularNumber === i + 1} onClick={() => setRegularNumber(i + 1)}>{i + 1}</Pill>
+                      <Pill tone="amber" key={i + 1} active={regularNumber === i + 1} onClick={() => setRegularNumber(i + 1)}>{i + 1}</Pill>
                     ))}
                   </div>
                 )}
@@ -394,49 +391,80 @@ const Shop: React.FC<{ gotoCorporate: () => void }> = ({ gotoCorporate }) => {
             {/* デザイン方式 */}
             <div className="flex flex-wrap gap-2">
               {flow !== "fullset" && (
-                <Pill active={designType === "name_print"} onClick={() => setDesignType("name_print")}>名前入れ</Pill>
+                <Pill tone="rose" active={designType === "name_print"} onClick={() => setDesignType("name_print")}>
+                  名前入れ
+                </Pill>
               )}
-              <Pill active={designType === "bring_own"} onClick={() => setDesignType("bring_own")}>デザイン持ち込み</Pill>
-              <Pill active={designType === "commission"} onClick={() => setDesignType("commission")}>デザイン依頼</Pill>
+              <Pill tone="rose" active={designType === "bring_own"} onClick={() => setDesignType("bring_own")}>
+                デザイン持ち込み
+              </Pill>
+              <Pill tone="rose" active={designType === "commission"} onClick={() => setDesignType("commission")}>
+                デザイン依頼
+              </Pill>
             </div>
 
             {/* 名前入れ */}
             {designType === "name_print" && (
-              <div className="grid md:grid-cols-2 gap-4 items-start mt-4">
-                <div className="space-y-3">
-                  <div className="flex items-center gap-2">
-                    <label className="w-24">文字</label>
-                    <input
-                      value={text}
-                      onChange={(e) => setText(e.target.value)}
-                      className="border rounded px-3 py-2 w-60"
-                      placeholder="縦4文字／横は自動改行"
-                    />
+              <div className="mt-4 grid gap-6 md:grid-cols-[minmax(0,220px)_minmax(0,1fr)] lg:grid-cols-[minmax(0,260px)_minmax(0,1fr)] md:items-start">
+                <div className="order-1 sticky top-16 md:order-none md:top-24">
+                  <div className="mx-auto w-full max-w-[210px] sm:max-w-[230px] md:max-w-[240px] lg:max-w-[260px]">
+                    <div className="rounded-2xl border border-neutral-200 bg-white/90 p-3 shadow-lg">
+                      <div className="mb-2 text-xs font-semibold tracking-wide text-neutral-500">プレビュー</div>
+                      <NameTilePreview
+                        text={text || "麻雀"}
+                        layout={layout}
+                        useUnifiedColor={useUnifiedColor}
+                        unifiedColor={unifiedColor}
+                        perCharColors={perCharColors}
+                        fontKey={fontKey}
+                        maxWidth={240}
+                        minWidth={160}
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                <div className="order-2 space-y-4 md:order-none">
+                  <div>
+                    <label className="block text-xs font-semibold text-neutral-500">文字</label>
+                    <div className="mt-2 w-full sm:w-60">
+                      <input
+                        value={text}
+                        onChange={(e) => setText(e.target.value)}
+                        className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 shadow-sm"
+                        placeholder="縦4文字／横は自動改行"
+                      />
+                    </div>
                   </div>
 
-                  <div className="flex items-center gap-2">
-                    <label className="w-24">レイアウト</label>
-                    <Pill active={layout === "vertical"} onClick={() => setLayout("vertical")}>縦</Pill>
-                    <Pill active={layout === "horizontal"} onClick={() => setLayout("horizontal")}>横</Pill>
-                  </div>
+                  <fieldset className="rounded-2xl border border-emerald-200/80 bg-emerald-50/60 p-4">
+                    <legend className="px-2 text-xs font-semibold uppercase tracking-wide text-emerald-700">レイアウト</legend>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      <Pill tone="emerald" active={layout === "vertical"} onClick={() => setLayout("vertical")}>縦</Pill>
+                      <Pill tone="emerald" active={layout === "horizontal"} onClick={() => setLayout("horizontal")}>横</Pill>
+                    </div>
+                  </fieldset>
 
-                  <div className="flex items-center gap-2">
-                    <label className="w-24">フォント</label>
-                    <Pill active={fontKey === "ta-fuga-fude"} onClick={() => setFontKey("ta-fuga-fude")}>萬子風</Pill>
-                    <Pill active={fontKey === "gothic"} onClick={() => setFontKey("gothic")}>ゴシック</Pill>
-                    <Pill active={fontKey === "mincho"} onClick={() => setFontKey("mincho")}>明朝</Pill>
-                  </div>
+                  <fieldset className="rounded-2xl border border-amber-200/80 bg-amber-50/60 p-4">
+                    <legend className="px-2 text-xs font-semibold uppercase tracking-wide text-amber-700">フォント</legend>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      <Pill tone="amber" active={fontKey === "ta-fuga-fude"} onClick={() => setFontKey("ta-fuga-fude")}>
+                        萬子風
+                      </Pill>
+                      <Pill tone="amber" active={fontKey === "gothic"} onClick={() => setFontKey("gothic")}>ゴシック</Pill>
+                      <Pill tone="amber" active={fontKey === "mincho"} onClick={() => setFontKey("mincho")}>明朝</Pill>
+                    </div>
+                  </fieldset>
 
-                  {/* 色指定 */}
-                  <div className="space-y-2">
-                    <div className="flex items-center gap-2">
-                      <label className="w-24">色指定</label>
-                      <Pill active={useUnifiedColor} onClick={() => setUseUnifiedColor(true)}>一括指定</Pill>
-                      <Pill active={!useUnifiedColor} onClick={() => setUseUnifiedColor(false)}>1文字ずつ</Pill>
+                  <fieldset className="space-y-3 rounded-2xl border border-slate-200/80 bg-slate-50/70 p-4">
+                    <legend className="px-2 text-xs font-semibold uppercase tracking-wide text-slate-700">色指定</legend>
+                    <div className="flex flex-wrap gap-2">
+                      <Pill tone="slate" active={useUnifiedColor} onClick={() => setUseUnifiedColor(true)}>一括指定</Pill>
+                      <Pill tone="slate" active={!useUnifiedColor} onClick={() => setUseUnifiedColor(false)}>1文字ずつ</Pill>
                     </div>
 
                     {useUnifiedColor ? (
-                      <div className="pl-24 grid grid-cols-3 gap-2 max-w-[420px]">
+                      <div className="grid max-w-[360px] grid-cols-2 gap-2 sm:grid-cols-3">
                         {COLOR_LIST.map((c) => (
                           <Pill key={c.key} active={unifiedColor === c.key} onClick={() => setUnifiedColor(c.key)}>
                             {renderDot(c.css)}
@@ -445,11 +473,11 @@ const Shop: React.FC<{ gotoCorporate: () => void }> = ({ gotoCorporate }) => {
                         ))}
                       </div>
                     ) : (
-                      <div className="pl-24 space-y-2">
+                      <div className="space-y-2">
                         {splitChars(text || "麻雀").map((ch, idx) => (
-                          <div key={idx} className="flex items-center gap-2">
-                            <div className="w-6 text-center text-sm">{ch}</div>
-                            <div className="grid grid-cols-3 gap-2">
+                          <div key={idx} className="flex flex-col gap-2 rounded-xl border border-slate-200 bg-white/60 px-3 py-3 sm:flex-row sm:items-center sm:gap-3">
+                            <div className="text-sm font-medium text-neutral-600 sm:w-8 sm:text-center">{ch}</div>
+                            <div className="grid flex-1 grid-cols-2 gap-2 sm:grid-cols-3">
                               {COLOR_LIST.map((c) => (
                                 <Pill
                                   key={c.key}
@@ -469,31 +497,16 @@ const Shop: React.FC<{ gotoCorporate: () => void }> = ({ gotoCorporate }) => {
                         ))}
                       </div>
                     )}
-                    <div className="pl-24 text-[12px] text-neutral-500">※ 他の色をご希望の場合は備考欄に記載ください。</div>
-                  </div>
+                    <div className="text-[12px] text-neutral-500">※ 他の色をご希望の場合は備考欄に記載ください。</div>
+                  </fieldset>
 
-                  {/* 備考 */}
-                  <div className="flex gap-2 items-start">
-                    <label className="w-24 mt-2">備考</label>
+                  <div>
+                    <label className="block text-xs font-semibold text-neutral-500">備考</label>
                     <textarea
                       value={note}
                       onChange={(e) => setNote(e.target.value)}
-                      className="border rounded-xl px-3 py-2 w-full h-40 md:h-48"
+                      className="mt-2 h-40 w-full rounded-2xl border border-neutral-200 bg-white px-3 py-2 shadow-sm md:h-48"
                       placeholder="ご希望・注意点など（任意）"
-                    />
-                  </div>
-                </div>
-
-                {/* プレビュー（右側） */}
-                <div className="flex justify-center md:justify-end">
-                  <div className="max-w-[460px] md:max-w-[420px]">
-                    <NameTilePreview
-                      text={text || "麻雀"}
-                      layout={layout}
-                      useUnifiedColor={useUnifiedColor}
-                      unifiedColor={unifiedColor}
-                      perCharColors={perCharColors}
-                      fontKey={fontKey}
                     />
                   </div>
                 </div>
@@ -545,7 +558,7 @@ const Shop: React.FC<{ gotoCorporate: () => void }> = ({ gotoCorporate }) => {
 
                   <div>
                     <label className="text-sm">色数</label>
-                    <div className="mt-1 flex items-center gap-2">
+                    <div className="mt-1 flex flex-col gap-2 sm:flex-row sm:items-center">
                       <input
                         type="number"
                         value={bringOwnColorCount}
@@ -553,7 +566,7 @@ const Shop: React.FC<{ gotoCorporate: () => void }> = ({ gotoCorporate }) => {
                           const v = Number(e.target.value);
                           setBringOwnColorCount(Number.isFinite(v) && v >= 1 ? Math.floor(v) : 1);
                         }}
-                        className="border rounded px-3 py-2 w-28"
+                        className="border rounded px-3 py-2 w-full sm:w-28"
                         inputMode="numeric"
                         pattern="[0-9]*"
                       />
@@ -593,8 +606,8 @@ const Shop: React.FC<{ gotoCorporate: () => void }> = ({ gotoCorporate }) => {
         {(flow === "original_single" || flow === "fullset") && (
           <Card title="3. サイズ選択">
             <div className="flex gap-2">
-              <Pill active={variant === "standard"} onClick={() => setVariant("standard")}>28mm</Pill>
-              <Pill active={variant === "mm30"} onClick={() => setVariant("mm30")}>30mm</Pill>
+              <Pill tone="indigo" active={variant === "standard"} onClick={() => setVariant("standard")}>28mm</Pill>
+              <Pill tone="indigo" active={variant === "mm30"} onClick={() => setVariant("mm30")}>30mm</Pill>
             </div>
 
             {/* 対応機種（選んだサイズだけ表示） */}
@@ -642,7 +655,7 @@ const Shop: React.FC<{ gotoCorporate: () => void }> = ({ gotoCorporate }) => {
 
         {/* 4. 数量 */}
         <Card title="4. 数量">
-          <div className="flex items-center gap-2">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
             <input
               type="number"
               value={qty}
@@ -650,7 +663,7 @@ const Shop: React.FC<{ gotoCorporate: () => void }> = ({ gotoCorporate }) => {
                 const v = Number(e.target.value);
                 setQty(Number.isFinite(v) && v >= 1 ? Math.floor(v) : 1);
               }}
-              className="border rounded px-3 py-2 w-28"
+              className="border rounded px-3 py-2 w-full sm:w-28"
               inputMode="numeric"
               pattern="[0-9]*"
             />
@@ -666,9 +679,9 @@ const Shop: React.FC<{ gotoCorporate: () => void }> = ({ gotoCorporate }) => {
           <div className="grid md:grid-cols-2 gap-4">
             <div className="space-y-3">
               {/* キーホルダー（独立数量：メイン数量より多く不可） */}
-              <div className="flex items-center justify-between rounded-xl border px-4 py-3">
+              <div className="flex flex-col gap-3 rounded-xl border px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
                 <div className="font-medium">キーホルダー</div>
-                <div className="flex items-center gap-2">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
                   <input
                     type="number"
                     value={optKeyholderQty}
@@ -676,7 +689,7 @@ const Shop: React.FC<{ gotoCorporate: () => void }> = ({ gotoCorporate }) => {
                       const v = Math.max(0, Math.floor(Number(e.target.value) || 0));
                       setOptKeyholderQty(Math.min(v, qty)); // メイン数量より多くは不可
                     }}
-                    className="border rounded px-3 py-2 w-24"
+                    className="border rounded px-3 py-2 w-full sm:w-24"
                     inputMode="numeric"
                     pattern="[0-9]*"
                   />
@@ -687,9 +700,9 @@ const Shop: React.FC<{ gotoCorporate: () => void }> = ({ gotoCorporate }) => {
               {/* 桐箱（28mm単品/通常のみ・独立数量） */}
               {((flow === "original_single" && variant === "standard") || flow === "regular") && (
                 <>
-                  <div className="flex items-center justify-between rounded-xl border px-4 py-3">
+                  <div className="flex flex-col gap-3 rounded-xl border px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
                     <div className="font-medium">桐箱（4枚用）</div>
-                    <div className="flex items-center gap-2">
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
                       <input
                         type="number"
                         value={optKiribakoQty}
@@ -697,7 +710,7 @@ const Shop: React.FC<{ gotoCorporate: () => void }> = ({ gotoCorporate }) => {
                           const v = Math.max(0, Math.floor(Number(e.target.value) || 0));
                           setOptKiribakoQty(v);
                         }}
-                        className="border rounded px-3 py-2 w-24"
+                        className="border rounded px-3 py-2 w-full sm:w-24"
                         inputMode="numeric"
                         pattern="[0-9]*"
                       />
@@ -756,18 +769,18 @@ const Shop: React.FC<{ gotoCorporate: () => void }> = ({ gotoCorporate }) => {
               </table>
             </div>
 
-            <div className="flex items-end justify-end gap-8">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end sm:gap-6">
               <button
                 type="button"
                 onClick={addToCart}
-                className="px-5 py-3 rounded-2xl border shadow-sm bg-white hover:bg-neutral-50"
+                className="w-full px-5 py-3 rounded-2xl border shadow-sm bg-white hover:bg-neutral-50 sm:w-auto"
               >
                 カートに追加
               </button>
               <button
                 type="button"
                 onClick={() => setMiniCartOpen(true)}
-                className="px-5 py-3 rounded-2xl bg-black text-white shadow"
+                className="w-full px-5 py-3 rounded-2xl bg-black text-white shadow sm:w-auto"
               >
                 購入手続きへ
               </button>
@@ -776,141 +789,145 @@ const Shop: React.FC<{ gotoCorporate: () => void }> = ({ gotoCorporate }) => {
         </Card>
       </section>
 
-{/* ===== ボトムバー（画面下“全面”、中央寄せ） ===== */}
-<div className="fixed left-0 right-0 bottom-0 z-30 border-t bg-white/95 backdrop-blur">
-  <div style={{ ...containerStyle }} className="px-4 pt-2 pb-2">
-    {/* 上段：合計サマリ */}
-    <div className="h-[44px] flex items-center justify-between">
-      <div className="text-sm">
-        <div className="font-semibold">カート</div>
-        <div className="text-neutral-600">
-          小計 ¥{fmt(cartTotals.preDiscount)} ・ 送料{" "}
-          {cartTotals.ship === 0 ? "¥0（無料）" : `¥${fmt(cartTotals.ship)}`}
-          {cartTotals.discount > 0 && (
-            <span className="text-rose-600 ml-2">
-              割引 -¥{fmt(cartTotals.discount)}
-            </span>
-          )}
-        </div>
-      </div>
-
-      <div className="flex items-center gap-3">
-        <div className="text-2xl font-bold mr-1">合計 ¥{fmt(cartTotals.total)}</div>
-
-        {/* 追加：購入手続きへ */}
-        <button
-          type="button"
-          className="px-5 py-2 rounded-xl bg-black text-white"
-          onClick={() => setMiniCartOpen(true)}
-        >
-          購入手続きへ
-        </button>
-
-        {/* 既存：カートに追加 */}
-        <button type="button" className="px-4 py-2 rounded-xl border" onClick={addToCart}>
-          カートに追加
-        </button>
-
-        {/* アコーディオン開閉 */}
-        <button
-          type="button"
-          className="px-5 py-2 rounded-xl bg-white border"
-          onClick={() => setMiniCartOpen((v) => !v)}
-          aria-expanded={miniCartOpen}
-          aria-controls="cart-accordion"
-        >
-          {miniCartOpen ? "カートを閉じる" : "カートを表示"}
-        </button>
-      </div>
-    </div>
-
-    {/* 下段：アコーディオン（開閉） */}
-    <div
-      id="cart-accordion"
-      className={`transition-[max-height] duration-300 ease-in-out overflow-hidden ${
-        miniCartOpen ? "max-h-[50vh]" : "max-h-0"
-      }`}
-    >
-      <div className="mt-3 border rounded-xl p-3 bg-white shadow-sm max-h-[46vh] overflow-auto">
-        {cartItems.length === 0 ? (
-          <div className="text-sm text-neutral-600 p-4 text-center">カートは空です。</div>
-        ) : (
-          <div className="space-y-3">
-            {cartItems.map((ci) => (
-              <div key={ci.id} className="border rounded-lg p-3">
-                <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <div className="font-medium">{ci.title}</div>
-                    <div className="text-sm text-neutral-600">数量：{ci.qty}</div>
-
-                    {ci.designSummary && (
-                      <div className="text-xs text-neutral-700 mt-1">
-                        <span className="font-semibold">デザイン：</span>
-                        {ci.designSummary}
-                      </div>
-                    )}
-
-                    {ci.thumbs && ci.thumbs.length > 0 && (
-                      <div className="mt-2 grid grid-cols-4 gap-2">
-                        {ci.thumbs.map((src, i) => (
-                          <img
-                            key={i}
-                            src={src}
-                            alt={`thumb_${i}`}
-                            className="w-full h-16 object-cover rounded border"
-                          />
-                        ))}
-                      </div>
-                    )}
-
-                    {ci.extras.length > 0 && (
-                      <div className="text-xs mt-2">
-                        <div className="font-semibold mb-1">オプション：</div>
-                        <ul className="list-disc ml-5 space-y-0.5">
-                          {ci.extras.map((e, i) => (
-                            <li key={i}>
-                              {e.label}：¥{fmt(e.amount)}
-                            </li>
-                          ))}
-                        </ul>
-                      </div>
-                    )}
-
-                    {ci.note && (
-                      <div className="text-xs text-neutral-600 mt-2">備考：{ci.note}</div>
-                    )}
-                  </div>
-
-                  <div className="text-right shrink-0">
-                    <div className="text-sm">
-                      小計：¥{fmt(ci.qty * ci.unit + ci.qty * (ci.optionTotal ?? 0))}
-                    </div>
-                    <button
-                      className="mt-2 px-2 py-1 rounded border text-xs"
-                      onClick={() => removeFromCart(ci.id)}
-                    >
-                      削除
-                    </button>
-                  </div>
-                </div>
+      {/* ===== ボトムバー（画面下“全面”、中央寄せ） ===== */}
+      <div className="fixed left-0 right-0 bottom-0 z-30 border-t bg-white/95 backdrop-blur">
+        <div style={{ ...containerStyle }} className="px-4 pt-2 pb-2">
+          {/* 上段：合計サマリ */}
+          <div className="flex flex-col gap-3 sm:h-[44px] sm:flex-row sm:items-center sm:justify-between">
+            <div className="text-sm">
+              <div className="font-semibold">カート</div>
+              <div className="text-neutral-600">
+                小計 ¥{fmt(cartTotals.preDiscount)} ・ 送料{" "}
+                {cartTotals.ship === 0 ? "¥0（無料）" : `¥${fmt(cartTotals.ship)}`}
+                {cartTotals.discount > 0 && (
+                  <span className="text-rose-600 ml-2">
+                    割引 -¥{fmt(cartTotals.discount)}
+                  </span>
+                )}
               </div>
-            ))}
-          </div>
-        )}
+            </div>
 
-        {/* 合計行（カート全体） */}
-        <div className="mt-3 border-t pt-3 text-right space-y-1">
-          <div>小計：¥{fmt(cartTotals.preDiscount)}</div>
-          {cartTotals.discount > 0 && (
-            <div className="text-rose-600">割引：-¥{fmt(cartTotals.discount)}</div>
-          )}
-          <div>送料：{cartTotals.ship === 0 ? "¥0（無料）" : `¥${fmt(cartTotals.ship)}`}</div>
-          <div className="text-lg font-semibold">合計：¥{fmt(cartTotals.total)}</div>
+            <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-center sm:gap-3">
+              <div className="text-2xl font-bold sm:mr-1">合計 ¥{fmt(cartTotals.total)}</div>
+
+              {/* 追加：購入手続きへ */}
+              <button
+                type="button"
+                className="w-full px-5 py-2 rounded-xl bg-black text-white sm:w-auto"
+                onClick={() => setMiniCartOpen(true)}
+              >
+                購入手続きへ
+              </button>
+
+              {/* 既存：カートに追加 */}
+              <button
+                type="button"
+                className="w-full px-4 py-2 rounded-xl border sm:w-auto"
+                onClick={addToCart}
+              >
+                カートに追加
+              </button>
+
+              {/* アコーディオン開閉 */}
+              <button
+                type="button"
+                className="w-full px-5 py-2 rounded-xl bg-white border sm:w-auto"
+                onClick={() => setMiniCartOpen((v) => !v)}
+                aria-expanded={miniCartOpen}
+                aria-controls="cart-accordion"
+              >
+                {miniCartOpen ? "カートを閉じる" : "カートを表示"}
+              </button>
+            </div>
+          </div>
+
+          {/* 下段：アコーディオン（開閉） */}
+          <div
+            id="cart-accordion"
+            className={`transition-[max-height] duration-300 ease-in-out overflow-hidden ${
+              miniCartOpen ? "max-h-[50vh]" : "max-h-0"
+            }`}
+          >
+            <div className="mt-3 border rounded-xl p-3 bg-white shadow-sm max-h-[46vh] overflow-auto">
+              {cartItems.length === 0 ? (
+                <div className="text-sm text-neutral-600 p-4 text-center">カートは空です。</div>
+              ) : (
+                <div className="space-y-3">
+                  {cartItems.map((ci) => (
+                    <div key={ci.id} className="border rounded-lg p-3">
+                      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                        <div className="min-w-0">
+                          <div className="font-medium">{ci.title}</div>
+                          <div className="text-sm text-neutral-600">数量：{ci.qty}</div>
+
+                          {ci.designSummary && (
+                            <div className="text-xs text-neutral-700 mt-1">
+                              <span className="font-semibold">デザイン：</span>
+                              {ci.designSummary}
+                            </div>
+                          )}
+
+                          {ci.thumbs && ci.thumbs.length > 0 && (
+                            <div className="mt-2 grid grid-cols-3 gap-2 sm:grid-cols-4">
+                              {ci.thumbs.map((src, i) => (
+                                <img
+                                  key={i}
+                                  src={src}
+                                  alt={`thumb_${i}`}
+                                  className="w-full h-16 object-cover rounded border"
+                                />
+                              ))}
+                            </div>
+                          )}
+
+                          {ci.extras.length > 0 && (
+                            <div className="text-xs mt-2">
+                              <div className="font-semibold mb-1">オプション：</div>
+                              <ul className="list-disc ml-5 space-y-0.5">
+                                {ci.extras.map((e, i) => (
+                                  <li key={i}>
+                                    {e.label}：¥{fmt(e.amount)}
+                                  </li>
+                                ))}
+                              </ul>
+                            </div>
+                          )}
+
+                          {ci.note && (
+                            <div className="text-xs text-neutral-600 mt-2">備考：{ci.note}</div>
+                          )}
+                        </div>
+
+                        <div className="mt-2 text-left sm:mt-0 sm:text-right sm:shrink-0">
+                          <div className="text-sm">
+                            小計：¥{fmt(ci.qty * ci.unit + ci.qty * (ci.optionTotal ?? 0))}
+                          </div>
+                          <button
+                            className="mt-2 px-2 py-1 rounded border text-xs"
+                            onClick={() => removeFromCart(ci.id)}
+                          >
+                            削除
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {/* 合計行（カート全体） */}
+              <div className="mt-3 border-t pt-3 space-y-1 text-left sm:text-right">
+                <div>小計：¥{fmt(cartTotals.preDiscount)}</div>
+                {cartTotals.discount > 0 && (
+                  <div className="text-rose-600">割引：-¥{fmt(cartTotals.discount)}</div>
+                )}
+                <div>送料：{cartTotals.ship === 0 ? "¥0（無料）" : `¥${fmt(cartTotals.ship)}`}</div>
+                <div className="text-lg font-semibold">合計：¥{fmt(cartTotals.total)}</div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
-    </div>
-  </div>
-</div>
 
       {/* トースト */}
       {toast && (


### PR DESCRIPTION
## Summary
- allow the name tile preview to accept min/max width overrides so it can shrink for compact layouts
- embed the name print preview in a sticky, narrow column beside the controls to keep updates visible while adjusting options

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6915e82a67bc832b9f6157b6779f4bd8)